### PR TITLE
Always use src/ directory when running tests

### DIFF
--- a/modules/core_dev/templates/wp-tests-config.php.erb
+++ b/modules/core_dev/templates/wp-tests-config.php.erb
@@ -1,12 +1,13 @@
 <?php
 // phpcs:ignoreFile
 
-/* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
-if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
-	define( 'ABSPATH', dirname( __FILE__ ) . '/build/' );
-} else {
-	define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
-}
+/*
+ * Path to the WordPress codebase you'd like to test, with a trailing slash.
+ *
+ * The Chassis/core_dev extension assumes you wish to run the tests directly
+ * against the wordpress-develop repository's src directory.
+ */
+define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
 
 /*
  * Path to the theme to test with.


### PR DESCRIPTION
The template here is based on the configuration from the tester extension, where we would usually want to be testing plugin or theme code rather than WordPress core. This extension is designed solely for testing WordPress core, and in that regard it makes more sense to always run tests against the `src/` directory: this is where you are going to be making your changes, and it can save a time-consuming rebuild step not to have to remember to set a constant if you don't want to use `build`.

With the number of tickets I've nearly objected to because I thought their tests were failing when I just hadn't remembered to rebuild, this should be a definite improvement!